### PR TITLE
Improves blindPosition support

### DIFF
--- a/blindcontroller/blindcontroller.html
+++ b/blindcontroller/blindcontroller.html
@@ -102,7 +102,7 @@
         defaults: {
             name:                 {value:""},
             mode:                 {value:"", required:true},
-            channel:              {value:"", required:true, validate:RED.validators.number()},
+            channel:              {value:"", required:true},
             orientation:          {value:"", required:true,
                                    validate: function (v) {
                 var n = Number(v);

--- a/blindcontroller/blindcontroller.js
+++ b/blindcontroller/blindcontroller.js
@@ -350,33 +350,6 @@ module.exports = function(RED) {
    */
   function validateBlindPositionMsg(node, msg) {
     var validMsg = true;
-    //var blindProperty = ["channel", "blindPosition"];
-    //var i;
-
-    // for (i in blindProperty) {
-      // if (!(blindProperty[i] in msg.payload)) {
-        // node.error(
-          // RED._("blindcontroller.error.blindPosition.missing-property") +
-            // blindProperty[i],
-          // msg
-        // );
-        // validMsg = false;
-      // }
-    // }
-    // if (validMsg) {
-      // if (
-        // typeof msg.payload.blindPosition != "number" ||
-        // msg.payload.blindPosition < 0 ||
-        // msg.payload.blindPosition > 100
-      // ) {
-        // node.error(
-          // RED._("blindcontroller.error.blindPosition.invalid-blindPosition") +
-            // msg.payload.blindPosition,
-          // msg
-        // );
-        // validMsg = false;
-      // }
-    // }
 	
 	if (
 		 msg.payload.reset && typeof msg.payload.reset != "boolean" 

--- a/blindcontroller/blindcontroller.js
+++ b/blindcontroller/blindcontroller.js
@@ -43,6 +43,9 @@ module.exports = function(RED) {
         case "blindPosition":
           validMsg = validateBlindPositionMsg(node, msg);
           break;
+        case "blindPositionReset":
+          validMsg = validateBlindPositionResetMsg(node, msg);
+          break;
         case "blind":
           validMsg = validateBlindMsg(node, msg);
           break;
@@ -352,17 +355,6 @@ module.exports = function(RED) {
     var validMsg = true;
 	
 	if (
-		 msg.payload.reset && typeof msg.payload.reset != "boolean" 
-		) {
-		node.error(
-		  RED._("blindcontroller.error.blind.invalid-reset") +
-			msg.payload.reset,
-		  msg
-		);
-		validMsg = false;
-		}
-	
-	if (
         msg.payload.expiryperiod &&
         (typeof msg.payload.expiryperiod != "number" ||
           msg.payload.expiryperiod < 0)
@@ -387,6 +379,26 @@ module.exports = function(RED) {
         );
         validMsg = false;
       }
+	
+    return validMsg;
+  }
+  
+  /*
+   * Validate Blind Position message
+   */
+  function validateBlindPositionResetMsg(node, msg) {
+    var validMsg = true;
+	
+	if (
+		 msg.payload.reset && typeof msg.payload.reset != "boolean" 
+		) {
+		node.error(
+		  RED._("blindcontroller.error.blind.invalid-reset") +
+			msg.payload.reset,
+		  msg
+		);
+		validMsg = false;
+		}
 	
     return validMsg;
   }
@@ -772,12 +784,17 @@ module.exports = function(RED) {
             break;
           case "blindPosition":
 			var blind = msg.payload.channel ? msg.payload.channel : this.blind.channel;
-			if(msg.payload.reset == true) {
-				resetPosition(node, msg, blinds[blind], sunPosition, weather );
-			} else {
-				setPosition(node, msg, blinds[blind]);
-			}
+			
+			setPosition(node, msg, blinds[blind]);
+			
             break;
+		  case "blindPositionReset":
+			var blind = msg.payload.channel ? msg.payload.channel : this.blind.channel;
+			
+			resetPosition(node, msg, blinds[blind], sunPosition, weather );
+			
+            break;
+			
           case "blind":
             var channel = msg.payload.channel;
             blinds[channel] = msg.payload;
@@ -939,11 +956,15 @@ module.exports = function(RED) {
             break;
           case "blindPosition":
 			var blind = msg.payload.channel ? msg.payload.channel : this.blind.channel;
-			if(msg.payload.reset == true) {
-				resetPosition(node, msg, blinds[blind], sunPosition, weather );
-			} else {
-				setPosition(node, msg, blinds[blind]);
-			}
+			
+			setPosition(node, msg, blinds[blind]);
+			
+            break;
+		  case "blindPositionReset":
+			var blind = msg.payload.channel ? msg.payload.channel : this.blind.channel;
+			
+			resetPosition(node, msg, blinds[blind], sunPosition, weather );
+			
             break;
           case "weather":
             weather = msg.payload;

--- a/blindcontroller/blindcontroller.js
+++ b/blindcontroller/blindcontroller.js
@@ -729,7 +729,8 @@ module.exports = function(RED) {
    */
   function calcBlindPositionExpiry(blind, expiryperiod) {
     var expiryTimestamp = new Date();
-    expiryTimestamp.setHours(expiryTimestamp.getHours() + (expiryperiod ? expiryperiod : blind.expiryperiod));
+    //expiryTimestamp.setHours(expiryTimestamp.getHours() + (expiryperiod ? expiryperiod : blind.expiryperiod));
+    expiryTimestamp.setMinutes(expiryTimestamp.getMinutes() + (expiryperiod ? expiryperiod : blind.expiryperiod));
     return expiryTimestamp;
   }
 


### PR DESCRIPTION
Following #22 this PR adds support for:

Reset manual override with msg.payload.reset = true
Set different expiry period with msg.payload.expiryperiod = x
Removes the need for msg.payload.channel on blindPosition messages
Sets node.status().fill to red when there's an active override
